### PR TITLE
Login should return client object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 # 0.2.0
 * Add support for IP address assignment
 * Reorganize actions modules
+
+# 0.2.1
+* Client `login!` should return the client instance 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proteus (0.2.0)
+    proteus (0.2.1)
       awesome_print (~> 0)
       gli (~> 2.15)
       mini_portile2 (~> 2.0)
@@ -95,4 +95,4 @@ DEPENDENCIES
   yard (~> 0)
 
 BUNDLED WITH
-   1.14.3
+   1.14.4

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gem 'proteus', git: 'https://github.com/YaleUniversity/proteus_client.git'
 or from the command line:
 
 ```
-git clone git://git.yale.edu/inf-sa/proteus_client.git
+git clone git@github.com:YaleUniversity/proteus_client.git
 cd proteus_client &&  gem build proteus.gemspec
 gem install proteus-*.gem
 

--- a/lib/proteus/client.rb
+++ b/lib/proteus/client.rb
@@ -36,6 +36,7 @@ module Proteus
     # </message>
     def login!
       @cookies = @client.call(:login, message: { username: @username, password: @password }).http.cookies
+      self
     end
 
     # logout of proteus api

--- a/lib/proteus/version.rb
+++ b/lib/proteus/version.rb
@@ -1,3 +1,3 @@
 module Proteus
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Let's me do this:

```ruby
Proteus::Client.new(config).login!.do_a_thing()
```

instead of this:

```ruby
client = Proteus::Client.new(config.to_h)
client.login!
client.do_a_thing()
```