### PR TITLE
Move `add_alias_record` to Alias module, cleanup comments to prep for documentation cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yml
 .ruby-*
 rspec.xml
 coverage
+doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 # 0.2.3
 * `compact` array response from `Proteus::Helpers.normalize`
 * Add rspec tests for Helpers, and ApiEntity
+
+# 0.2.4
+* Move `add_alias_record` to `Proteus::Actions::Alias`
+* Cleanup comments in preparation for documentation cleanup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proteus (0.2.3)
+    proteus (0.2.4)
       awesome_print (~> 0)
       gli (~> 2.15)
       mini_portile2 (~> 2.0)

--- a/lib/proteus/actions.rb
+++ b/lib/proteus/actions.rb
@@ -1,4 +1,5 @@
 module Proteus
+  ##
   # Actions is the top level module for API actions
   module Actions
     require 'proteus/actions/entity'
@@ -19,7 +20,8 @@ module Proteus
     include Proteus::Actions::Ipv4
     include Proteus::Actions::Zone
 
-    # make a call to the api
+    ##
+    # Makes a call to the proteus API
     def call(action, message = nil)
       @logger.info "call_action: #{action}, message: #{message.inspect}"
       api_response_obj = (action.to_s + '_response').to_sym
@@ -31,10 +33,11 @@ module Proteus
       response
     end
 
-    # gets some system information
-    # <message name="ProteusAPI_getSystemInfoResponse">
-    #   <part name="return" type="xsd:string"/>
-    # </message>
+    ##
+    # Gets system information from the proteus API
+    #   <message name="ProteusAPI_getSystemInfoResponse">
+    #     <part name="return" type="xsd:string"/>
+    #   </message>
     def system_info
       Proteus::SystemInfo.new call(:get_system_info)
     end

--- a/lib/proteus/actions/alias.rb
+++ b/lib/proteus/actions/alias.rb
@@ -1,15 +1,32 @@
 module Proteus
   module Actions
+    ##
+    # This module encapsulates the actions related to managing Alias records
     module Alias
-      # get a list of alias records by a hint
-      # <message name="ProteusAPI_getAliasesByHint">
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      #   <part name="options" type="xsd:string"/>
-      # </message>
+      ##
+      # Get a list of alias records by a hint
+      #   <message name="ProteusAPI_getAliasesByHint">
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #     <part name="options" type="xsd:string"/>
+      #   </message>
       def get_aliases_by_hint(start = 0, count = 10, options = '')
         response = call(:get_aliases_by_hint, start: start, count: count, options: options)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }
+      end
+
+      ##
+      # Add an alias record
+      #   <message name="ProteusAPI_addAliasRecord">
+      #     <part name="viewId" type="xsd:long"/>
+      #     <part name="absoluteName" type="xsd:string"/>
+      #     <part name="linkedRecordName" type="xsd:string"/>
+      #     <part name="ttl" type="xsd:long"/>
+      #     <part name="properties" type="xsd:string"/>
+      #   </message>
+      def add_alias_record(cname, linked, ttl = -1, properties = '')
+        call(:add_alias_record, viewId: @view_id, absoluteName: cname,
+             linkedRecordName: linked, ttl: ttl, properties: properties)
       end
     end
   end

--- a/lib/proteus/actions/entity.rb
+++ b/lib/proteus/actions/entity.rb
@@ -1,30 +1,37 @@
 module Proteus
   module Actions
+    ##
+    # This module encapsulates the actions related to managing generic entities
+    # through the proteus API.
     module Entity
-      # get parent entity
-      # <message name="ProteusAPI_getParent">
-      #   <part name="entityId" type="xsd:long"/>
-      # </message>
+      ##
+      # Gets the parent entity from an entityId
+      #   <message name="ProteusAPI_getParent">
+      #     <part name="entityId" type="xsd:long"/>
+      #   </message>
       def get_parent(id = nil)
         Proteus::ApiEntity.new call(:get_parent, entityId: id || @view_id)
       end
 
-      # get top level configurations
-      # <message name="ProteusAPI_getEntities">
-      #   <part name="parentId" type="xsd:long"/>
-      #   <part name="type" type="xsd:string"/>
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      # </message>
+      ##
+      # Gets a list of entities from a parent entity ID and an entity type.
+      # By default it returns the top level configuration
+      #   <message name="ProteusAPI_getEntities">
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="type" type="xsd:string"/>
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #   </message>
       def get_entities(parent_id = 0, type = Proteus::Types::CONFIGURATION, start = 0, count = 10)
         response = call(:get_entities, parentId: parent_id, type: type, start: start, count: count)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }
       end
 
-      # deletes an object by id
-      # <message name="ProteusAPI_delete">
-      #   <part name="objectId" type="xsd:long"/>
-      # </message>
+      ##
+      # Deletes an entity by entityId
+      #   <message name="ProteusAPI_delete">
+      #     <part name="objectId" type="xsd:long"/>
+      #   </message>
       def delete(id)
         entity = get_entity_by_id(id)
         if ALLOWDELETE.include?(entity.type)
@@ -35,64 +42,73 @@ module Proteus
         end
       end
 
-      # get entity by id
-      # <message name="ProteusAPI_getEntityById">
-      #   <part name="id" type="xsd:long"/>
-      # </message>
+      ##
+      # Gets an entity by entityId
+      #   <message name="ProteusAPI_getEntityById">
+      #     <part name="id" type="xsd:long"/>
+      #   </message>
       def get_entity_by_id(id = nil)
         Proteus::ApiEntity.new call(:get_entity_by_id, id: id || @view_id)
       end
 
-      # get entity by name
-      # <message name="ProteusAPI_getEntityById">
-      #   <part name="id" type="xsd:long"/>
-      # </message>
+      ##
+      # Gets an entity by name
+      # Finding a specific entity by name requires the parentId and the type of entity
+      #   <message name="ProteusAPI_getEntityByName">
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="name" type="xsd:string"/>
+      #     <part name="type" type="xsd:string"/>
+      #   </message>
       def get_entity_by_name(parent_id = 0, name, type)
         parent_id ||= @view_id
         Proteus::ApiEntity.new call(:get_entity_by_name, parentId: parent_id, name: name, type: type)
       end
 
-      # get entity by CIDR
-      # <message name="ProteusAPI_getEntityByCIDR">
-      #   <part name="parentId" type="xsd:long"/>
-      #   <part name="cidr" type="xsd:string"/>
-      #   <part name="type" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets an entity by CIDR
+      #   <message name="ProteusAPI_getEntityByCIDR">
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="cidr" type="xsd:string"/>
+      #     <part name="type" type="xsd:string"/>
+      #   </message>
       def get_entity_by_cidr(parent_id = 0, cidr = '0.0.0.0/0', type = Proteus::Types::IP4NETWORK)
         parent_id ||= @view_id
         Proteus::ApiEntity.new call(:get_entity_by_cidr, parentId: parent_id, CIDR: cidr, type: type)
       end
 
-      # get entity by Range
-      # <message name="ProteusAPI_getEntityByCIDR">
-      #   <part name="parentId" type="xsd:long"/>
-      #   <part name="cidr" type="xsd:string"/>
-      #   <part name="type" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets an entity by Range
+      #   <message name="ProteusAPI_getEntityByCIDR">
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="cidr" type="xsd:string"/>
+      #     <part name="type" type="xsd:string"/>
+      #   </message>
       def get_entity_by_range(parent_id = 0, addr1 = '0.0.0.0', addr2 = '0.0.0.0', type = Proteus::Types::IP4NETWORK)
         parent_id ||= @view_id
         Proteus::ApiEntity.new call(:get_entity_by_range, parentId: parent_id, address1: addr1, address2: addr2, type: type)
       end
 
-      # search by categories
-      # <message name="ProteusAPI_searchByCategory">
-      #   <part name="keyword" type="xsd:string"/>
-      #   <part name="category" type="xsd:string"/>
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      # </message>
+      ##
+      # Search for entities by category and a keyword
+      #    <message name="ProteusAPI_searchByCategory">
+      #     <part name="keyword" type="xsd:string"/>
+      #     <part name="category" type="xsd:string"/>
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #   </message>
       def search_by_category(keyword, category = 'ALL', start = 0, count = 10)
         response = call(:search_by_category, keyword: keyword, category: category, start: start, count: count)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }
       end
 
-      # search by object types
-      # <message name="ProteusAPI_searchByObjectTypes">
-      #   <part name="keyword" type="xsd:string"/>
-      #   <part name="types" type="xsd:string"/>
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      # </message>
+      ##
+      # Search for entities by object types and a keyword
+      #   <message name="ProteusAPI_searchByObjectTypes">
+      #     <part name="keyword" type="xsd:string"/>
+      #     <part name="types" type="xsd:string"/>
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #   </message>
       def search_by_object_types(keyword, types = Proteus::Types::GENERICRECORD, start = 0, count = 10)
         response = call(:search_by_object_types, keyword: keyword, types: types, start: start, count: count)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }

--- a/lib/proteus/actions/host.rb
+++ b/lib/proteus/actions/host.rb
@@ -1,48 +1,40 @@
 module Proteus
   module Actions
+    ##
+    # This module encapsulates the actions related to managing Host records through the proteus API.
     module Host
-      # add host record
-      # <message name="ProteusAPI_addHostRecord">
-      #   <part name="viewId" type="xsd:long"/>
-      #   <part name="absoluteName" type="xsd:string"/>
-      #   <part name="addresses" type="xsd:string"/>
-      #   <part name="ttl" type="xsd:long"/>
-      #   <part name="properties" type="xsd:string"/>
-      # </message>
+      ##
+      # Adds a host record
+      #   <message name="ProteusAPI_addHostRecord">
+      #     <part name="viewId" type="xsd:long"/>
+      #     <part name="absoluteName" type="xsd:string"/>
+      #     <part name="addresses" type="xsd:string"/>
+      #     <part name="ttl" type="xsd:long"/>
+      #     <part name="properties" type="xsd:string"/>
+      #   </message>
       def add_host_record(fqdn, ip, ttl = -1, properties = '')
         call(:add_host_record, viewId: @view_id, absoluteName: fqdn,
              addresses: ip, ttl: ttl, properties: properties)
       end
 
-      # add alias record
-      # <message name="ProteusAPI_addAliasRecord">
-      #   <part name="viewId" type="xsd:long"/>
-      #   <part name="absoluteName" type="xsd:string"/>
-      #   <part name="linkedRecordName" type="xsd:string"/>
-      #   <part name="ttl" type="xsd:long"/>
-      #   <part name="properties" type="xsd:string"/>
-      # </message>
-      def add_alias_record(cname, linked, ttl = -1, properties = '')
-        call(:add_alias_record, viewId: @view_id, absoluteName: cname,
-             linkedRecordName: linked, ttl: ttl, properties: properties)
-      end
-
-      # add external host record
-      # <message name="ProteusAPI_addExternalHostRecord">
-      #   <part name="viewId" type="xsd:long"/>
-      #   <part name="name" type="xsd:string"/>
-      #   <part name="properties" type="xsd:string"/>
-      # </message>
+      ##
+      # Adds an external host record
+      #   <message name="ProteusAPI_addExternalHostRecord">
+      #     <part name="viewId" type="xsd:long"/>
+      #     <part name="name" type="xsd:string"/>
+      #     <part name="properties" type="xsd:string"/>
+      #   </message>
       def add_external_host_record(name, properties = '')
         call(:add_external_host_record, viewId: @view_id, name: name, properties: properties )
       end
 
-      # get a list of host records by a hint
-      # <message name="ProteusAPI_getHostRecordsByHint">
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      #   <part name="options" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets a list of host records by a hint
+      #   <message name="ProteusAPI_getHostRecordsByHint">
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #     <part name="options" type="xsd:string"/>
+      #   </message>
       def get_host_records_by_hint(start = 0, count = 10, options = '')
         response = call(:get_host_records_by_hint, start: start, count: count, options: options)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }

--- a/lib/proteus/actions/ipv4.rb
+++ b/lib/proteus/actions/ipv4.rb
@@ -1,45 +1,51 @@
 module Proteus
   module Actions
+    ##
+    # This module encapsulates the actions related to managing IPv4 entities through the proteus API.
     module Ipv4
-      # assigns the next available IP in a network
-      # <message name="ProteusAPI_assignNextAvailableIP4Address">
-      #   <part name="configurationId" type="xsd:long"/>
-      #   <part name="parentId" type="xsd:long"/>
-      #   <part name="macAddress" type="xsd:string"/>
-      #   <part name="hostInfo" type="xsd:string"/>
-      #   <part name="action" type="xsd:string"/>
-      #   <part name="properties" type="xsd:string"/>
-      # </message>
+      ##
+      # Assigns the next available IP in a network
+      #   <message name="ProteusAPI_assignNextAvailableIP4Address">
+      #     <part name="configurationId" type="xsd:long"/>
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="macAddress" type="xsd:string"/>
+      #     <part name="hostInfo" type="xsd:string"/>
+      #     <part name="action" type="xsd:string"/>
+      #     <part name="properties" type="xsd:string"/>
+      #   </message>
       def assign_next_available_ip4_address(config_id, parent_id, mac, host_info, action, properties)
         call(:assign_next_available_ip4_address, configurationId: config_id, parentId: parent_id,
              macAddress: mac, hostInfo: host_info, action: action, properties: properties)
       end
 
-      # get an IPv4 address by configuration id and ip
-      # <message name="ProteusAPI_getIP4Address">
-      #   <part name="containerId" type="xsd:long"/>
-      #   <part name="address" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets an IPv4 address by configuration id and ip
+      #   <message name="ProteusAPI_getIP4Address">
+      #     <part name="containerId" type="xsd:long"/>
+      #     <part name="address" type="xsd:string"/>
+      #   </message>
       def get_ip4_address(config_id, address)
         Proteus::ApiEntity.new call(:get_ip4_address, containerId: config_id, address: address)
       end
 
-      # get the next IPv4 address
-      # <message name="ProteusAPI_getNextIP4Address">
-      #   <part name="parentId" type="xsd:long"/>
-      #   <part name="properties" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets the next available IPv4 address, but doesn't assign it
+      #   <message name="ProteusAPI_getNextIP4Address">
+      #     <part name="parentId" type="xsd:long"/>
+      #     <part name="properties" type="xsd:string"/>
+      #   </message>
       def get_next_ip4_address(parent_id, properties = '')
         call(:get_next_ip4_address, parentId: parent_id, properties: properties)
       end
 
-      # get IPv4 networks by a hint
-      # <message name="ProteusAPI_getIP4NetworksByHint">
-      #   <part name="containerId" type="xsd:long"/>
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      #   <part name="options" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets a list of IPv4 networks by a hint
+      #   <message name="ProteusAPI_getIP4NetworksByHint">
+      #     <part name="containerId" type="xsd:long"/>
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #     <part name="options" type="xsd:string"/>
+      #   </message>
       def get_ip4_networks_by_hint(container_id = 0, start = 0, count = 10, options = '')
         response = call(:get_ip4_networks_by_hint, containerId: container_id, start: start, count: count, options: options)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }

--- a/lib/proteus/actions/zone.rb
+++ b/lib/proteus/actions/zone.rb
@@ -1,13 +1,16 @@
 module Proteus
   module Actions
+    ##
+    # This module encapsulates the actions related to managing zone entities through the proteus API.
     module Zone
-      # get a list of zones by a hint
-      # <message name="ProteusAPI_getZonesByHint">
-      #   <part name="containerId" type="xsd:long"/>
-      #   <part name="start" type="xsd:int"/>
-      #   <part name="count" type="xsd:int"/>
-      #   <part name="options" type="xsd:string"/>
-      # </message>
+      ##
+      # Gets a list of zones from a hint
+      #   <message name="ProteusAPI_getZonesByHint">
+      #     <part name="containerId" type="xsd:long"/>
+      #     <part name="start" type="xsd:int"/>
+      #     <part name="count" type="xsd:int"/>
+      #     <part name="options" type="xsd:string"/>
+      #   </message>
       def get_zones_by_hint(container_id = 0, start = 0, count = 10, options = '')
         response = call(:get_zones_by_hint, containerId: container_id, start: start, count: count, options: options)
         normalize(response).collect { |i| Proteus::ApiEntity.new(i) }

--- a/lib/proteus/api_entity.rb
+++ b/lib/proteus/api_entity.rb
@@ -1,4 +1,5 @@
 module Proteus
+  ##
   # ApiEntity describes an API service Entity object
   #   @id: The database ID of the object in Address Manager.
   #   @name: The field name, which might be null.

--- a/lib/proteus/client.rb
+++ b/lib/proteus/client.rb
@@ -1,6 +1,6 @@
-# Module to hold Proteus related classes
 module Proteus
-  # Class to describe a Proteus client
+  ##
+  # Class to describe a Proteus client object
   class Client
     require 'logger'
     require 'savon'
@@ -10,6 +10,7 @@ module Proteus
 
     attr_accessor :user, :password, :view_id
 
+    ##
     # Initialize a proteus [soap] client.  Expect the options hash to contain:
     # user, password, default_viewid, url
     def initialize(options = {})
@@ -29,18 +30,20 @@ module Proteus
       end
     end
 
-    # login to proteus api and return authorization cookie
-    # <message name="ProteusAPI_login">
-    #   <part name="username" type="xsd:string"/>
-    #   <part name="password" type="xsd:string"/>
-    # </message>
+    ##
+    # Login to the proteus api and return an authorization cookie
+    #   <message name="ProteusAPI_login">
+    #     <part name="username" type="xsd:string"/>
+    #     <part name="password" type="xsd:string"/>
+    #   </message>
     def login!
       @cookies = @client.call(:login, message: { username: @username, password: @password }).http.cookies
       self
     end
 
-    # logout of proteus api
-    # <message name="ProteusAPI_logout"/>
+    ##
+    # Logout of the proteus api
+    #   <message name="ProteusAPI_logout"/>
     def logout!
       @client.call(:logout) { |ctx| ctx.cookies @cookies }
     end

--- a/lib/proteus/constants.rb
+++ b/lib/proteus/constants.rb
@@ -1,4 +1,6 @@
 module Proteus
+  ##
+  # A module to encapsulate the proteus standard types
   module Types
     CONFIGURATION   = 'Configuration'
     VIEW            = 'View'

--- a/lib/proteus/helpers.rb
+++ b/lib/proteus/helpers.rb
@@ -1,9 +1,13 @@
 module Proteus
+  ##
   # Helpers module to collect useful utility methods for
   # dealing with the input to and output from the Proteus API
   module Helpers
-    # decompose takes a property string of the form: "foo=bar|baz=biz|boz=buz"
-    # and decomposes it into a ruby hash { foo: 'bar', baz: 'biz', boz: 'buz' }
+    ##
+    # decompose takes a property string of the form:
+    #   "foo=bar|baz=biz|boz=buz"
+    # and decomposes it into a ruby hash:
+    #   { foo: 'bar', baz: 'biz', boz: 'buz' }
     def decompose(prop_string)
       return nil if prop_string.nil?
       props = {}
@@ -14,8 +18,11 @@ module Proteus
       props
     end
 
-    # compose takes a a ruby hash { foo: 'bar', baz: 'biz', boz: 'buz' } and
-    # composes it into a property string of the form: "foo=bar|baz=biz|boz=buz"
+    ##
+    # compose takes a a ruby hash:
+    #   { foo: 'bar', baz: 'biz', boz: 'buz' }
+    # and composes it into a property string of the form:
+    #   "foo=bar|baz=biz|boz=buz"
     def compose(prop_hash)
       return nil if prop_hash.nil?
       prop_hash.map do |k, v|
@@ -23,10 +30,12 @@ module Proteus
       end.join('|')
     end
 
+    ##
     # normalize cleans up the response from the api --
-    # when there is 1 item, the response is a hash: { item: { foo: 'bar', baz: 'biz' } },
+    # when there is 1 item, the response is a hash:
+    #   { item: { foo: 'bar', baz: 'biz' } }
     # but when there is >1 item, the response is a list:
-    # { item: [ { foo: 'bar', baz: 'biz' }, { foo: 'boz', baz: 'buz' } ]
+    #   { item: [ { foo: 'bar', baz: 'biz' }, { foo: 'boz', baz: 'buz' } ]
     def normalize(hash)
       hash ||= {}
       [hash[:item]].flatten.compact

--- a/lib/proteus/system_info.rb
+++ b/lib/proteus/system_info.rb
@@ -1,4 +1,5 @@
 module Proteus
+  ##
   # SystemInfo describes a proteus system information object
   #   @hostname: The host name of the Address Manager server.
   #   @version: The version of the Address Manager software
@@ -15,6 +16,8 @@ module Proteus
     attr_reader :hostname, :version, :address, :cluster_role, :replication_role, :replication_status,
                 :entity_count, :database_size, :logged_in_users
 
+    ##
+    # initialize a proteus system information object from a properties hash
     def initialize(properties)
       attributes = decompose(properties)
       @hostname = attributes[:hostName]
@@ -28,6 +31,8 @@ module Proteus
       @logged_in_users = attributes[:loggedInUsers]
     end
 
+    ##
+    # create a string representation of a proteus system information object
     def inspect
       instance_variables.collect do |v|
         "#{v.to_s.gsub('@','')}: #{instance_variable_get(v)}"

--- a/lib/proteus/version.rb
+++ b/lib/proteus/version.rb
@@ -1,3 +1,5 @@
+##
+# This is the top-level proteus module
 module Proteus
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end


### PR DESCRIPTION
I'm planning to write YARD doc for this gem, just trying to get some of the comments cleaned up.  These _should_ work fine for rdoc now.