### PR TITLE
Modify semver syntax to avoid pessimistic dependency error

### DIFF
--- a/proteus.gemspec
+++ b/proteus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib lib/proteus lib/actions)
 
   spec.add_dependency 'awesome_print', '~> 0'
-  spec.add_dependency 'cri', '~> 2.7.1'
+  spec.add_dependency 'cri', '~> 2.7', '>= 2.7.1'
   spec.add_dependency 'mini_portile2', '~> 2.0'
   spec.add_dependency 'netaddr', '~> 1.5', '>= 1.5.1'
   spec.add_dependency 'savon', '~> 2.0'


### PR DESCRIPTION
When running:

`cd proteus_client &&  gem build proteus.gemspec`

I received this error:
```
WARNING:  pessimistic dependency on cri (~> 2.7.1) may be overly strict
  if cri is semantically versioned, use:
    add_runtime_dependency 'cri', '~> 2.7', '>= 2.7.1'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: proteus
  Version: 0.5.0
  File: proteus-0.5.0.gem
```

Modifying this line results in a successful build.