### PR TITLE
add config input checks, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,22 @@ url: 'https://proteus.example.com'
 username: 'api_user'
 password: 'xxx'
 viewid: '123456'
-log_level: warn
+loglevel: warn
 ```
 
 ### Authors
   - Camden Fisher (camden.fisher@yale.edu)
   - Tenyo Grozev (tenyo.grozev@yale.edu)
   - Jose Andrade (jose.andrade@yale.edu)
+
+### Issues
+  - Badly formed command line authentication arguments will return 'undefined method logout!'.  Arguments such as --config_file go at the end of the command after commands and options.  A mis-formed YAML --config_file sometimes produces 'undefined method logout!'
+  - it's better to use no 'equals' sign, just a space, for the arguments
+```
+     E.g.,
+       proteus info --config_file config/config.yml
+       proteus info --config_file ~/proteus.onfig
+```
 
 ### License
 ```

--- a/exe/proteus
+++ b/exe/proteus
@@ -22,6 +22,9 @@ SUBCOMMANDS = %w(AliasCommands EntityCommands ExternalHostCommands HostCommands 
 
 def configure(opts)
   if opts[:config_file]
+    if !(File.file?(opts[:config_file]))
+      exit_2("config file not found: #{opts[:config_file]}")
+    end
     $stdout.puts "Reading configuration from #{opts[:config_file]}."
     @config = OpenStruct.new(YAML.load_file(opts[:config_file]))
   else
@@ -34,6 +37,13 @@ def configure(opts)
         loglevel: opts[:loglevel] || 'warn'
       }
     )
+  end
+  # sanity check variables before proceeding to login!
+  if @config.url == nil ||
+     @config.username == nil ||
+     @config.password == nil ||
+     @config.viewid == nil
+    exit_2("configs missing")
   end
 end
 


### PR DESCRIPTION
I added a file existence check for the config file.  Also, a check that @config items are not null after they are assigned.   I updated the README with more examples to show that --config_file must come last in the argument list - possibly we can make this more up front, so as to cause less confusion and prevent the dreaded 'undefined method `logout!'